### PR TITLE
Add a method to walk and mutate changes

### DIFF
--- a/nconv.go
+++ b/nconv.go
@@ -5,6 +5,7 @@ package fxml
 
 import (
 	"fmt"
+	"strings"
 )
 
 type (
@@ -39,7 +40,7 @@ type (
 
 // Initialize the converter.  This function is called by the parser internally.
 func (ic *NConv) Init(charset string) error {
-	if charset != "UTF-8" {
+	if strings.ToUpper(charset) != "UTF-8" {
 		return fmt.Errorf("invalid charset '%s' (UTF-8 only)", charset)
 	}
 	return nil


### PR DESCRIPTION
Callers are expected to return x as well as the byte for whether to continue or stop

Example below can be added to docs later if you want:

```
	var filename = "forward_10-24px.svg"
	f, err := os.Open(filename)
	if err != nil {
		return
	}
	defer f.Close()
	xt, err := fxml.Parse(f)
	if err != nil {
		return
	}
	newXML := xt.WalkMutate(func(ni fxml.XNodInfo, x *fxml.XMLTree) (fxml.XWalkResult, *fxml.XMLTree) {
		if ni.Path[len(ni.Path)-1] == "path" {
			addFill := true
			for idx, _ := range x.Attr {
				if x.Attr[idx].Name.Local == "fill" && x.Attr[idx].Value == "none" {
					addFill = false
				} else if x.Attr[idx].Name.Local == "fill" {
					x.Attr[idx].Value = "red"
					addFill = false
				}
			}
			if addFill {
				x.Attr = append(x.Attr, xml.Attr{
					Name: xml.Name{
						Local: "fill",
					},
					Value: "red",
				})
			}
		}
		if ni.Path[len(ni.Path)-1] == "circle" {
			addFill := true
			for idx, _ := range x.Attr {
				if x.Attr[idx].Name.Local == "fill" && x.Attr[idx].Value == "none" {
					addFill = false
				} else if x.Attr[idx].Name.Local == "fill" {
					x.Attr[idx].Value = "red"
					addFill = false
				}
			}
			if addFill {
				x.Attr = append(x.Attr, xml.Attr{
					Name: xml.Name{
						Local: "fill",
					},
					Value: "red",
				})
			}
		}

		if ni.Path[len(ni.Path)-1] == "polygon" {
			x.Attr = append(x.Attr, xml.Attr{
				Name: xml.Name{
					Local: "style",
				},
				Value: "fill: red;",
			})
		}

		if ni.Path[len(ni.Path)-1] == "rect" {
			addFill := true
			for idx, _ := range x.Attr {
				if x.Attr[idx].Name.Local == "fill" && x.Attr[idx].Value == "none" {
					addFill = false
				} else if x.Attr[idx].Name.Local == "fill" {
					x.Attr[idx].Value = "red"
					addFill = false
				}
			}
			if addFill {
				x.Attr = append(x.Attr, xml.Attr{
					Name: xml.Name{
						Local: "style",
					},
					Value: "fill: red;",
				})
			}
		}
		return fxml.WRCont, x
	})
	newXML.Encode(os.Stdout, true)
```

Here is the forward svg file:

```
<?xml version="1.0" encoding="utf-8"?>
<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="24px"
	 height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
<g id="Bounding_Box">
	<rect fill="none" width="24" height="24"/>
</g>
<g id="Icons">
	<g>
		<path d="M18,13c0,3.31-2.69,6-6,6s-6-2.69-6-6s2.69-6,6-6v4l5-5l-5-5v4c-4.42,0-8,3.58-8,8c0,4.42,3.58,8,8,8s8-3.58,8-8H18z"/>
		<polygon points="10.86,15.94 10.86,11.67 10.77,11.67 9,12.3 9,12.99 10.01,12.68 10.01,15.94 		"/>
		<path d="M12.25,13.44v0.74c0,1.9,1.31,1.82,1.44,1.82c0.14,0,1.44,0.09,1.44-1.82v-0.74c0-1.9-1.31-1.82-1.44-1.82
			C13.55,11.62,12.25,11.53,12.25,13.44z M14.29,13.32v0.97c0,0.77-0.21,1.03-0.59,1.03c-0.38,0-0.6-0.26-0.6-1.03v-0.97
			c0-0.75,0.22-1.01,0.59-1.01C14.07,12.3,14.29,12.57,14.29,13.32z"/>
	</g>
</g>
</svg>

```

Also added a bug fix for the lower cased utf-8 example.

Nice job on this.  Super useful package for parsing SVGs which I needed to do here.